### PR TITLE
Escape domain names in alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ This tool augments [dnstwist](https://github.com/elceef/dnstwist) with a databas
 following environment variables:
     * `GFYP_EMAIL_USERNAME`
     * `GFYP_EMAIL_PASSWORD`
-    * `GFYP_EMAIL_STMPSERVER`
+    * `GFYP_EMAIL_SMTPSERVER`
 
 Ex.
 
     $ export GFYP_EMAIL_USERNAME=alice@example.com
     $ export GFYP_EMAIL_PASSWORD=ilovemallory
-    $ export GFYP_EMAIL_STMPSERVER=smtp.example.com
+    $ export GFYP_EMAIL_SMTPSERVER=smtp.example.com
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,35 @@
-# GFYP - Go "Find Your" Phishers
+# GFYP - Go Find Your Phishers
 
-Having experimented with dnstwist for some time now, it dawned on me that it could be useful for alerting of new domains as they pop up related to your domains of interest. 
-
-For more information on dnstwist, see https://github.com/elceef/dnstwist
+This tool augments [dnstwist](https://github.com/elceef/dnstwist) with a database that tracks identified phishing sites over times, and provides email alerts when new ones are discovered.
 
 ## Installation
-* pip install -r requirements.txt
-* Add notification email information (username/password) to the top of core.py
-* python util.py build
-* python util.py add (domain name) (email address)
-* python core.py (or set it as a cron job)  - Start getting information reports hourly.
 
-## Notes
-Yes I know some of the coding is horrible. I'm going to be cleaning it up sometime in the next few weeks here when I get some time, just wanting to share it for now.
+    $ pip install -r requirements.txt
+
+## Configuration
+
+1. Initialize database with `python util.py build`
+2. Either add your SMTP credentials by hard-coding them in core.py, or set the
+following environment variables:
+    * `GFYP_EMAIL_USERNAME`
+    * `GFYP_EMAIL_PASSWORD`
+    * `GFYP_EMAIL_STMPSERVER`
+
+Ex.
+
+    $ export GFYP_EMAIL_USERNAME=alice@example.com
+    $ export GFYP_EMAIL_PASSWORD=ilovemallory
+    $ export GFYP_EMAIL_STMPSERVER=smtp.example.com
+
+## Usage
+
+    # add domain to list for which to hunt phishing domains
+    python util.py add (domain name) (email address)
+    # start searching process
+    python core.py # or set it as a cron job to regular reports
+
+## Troubleshooting
+
+### GMail
+
+If using GMail as an SMTP provider, you may first need to log into GMail in the web interface and enable the "Allow less secure apps" option in the "Sign-in & security" section.

--- a/common.py
+++ b/common.py
@@ -1,0 +1,14 @@
+"""Shared functions and constants"""
+import sys
+
+BOLD = ""
+END = ""
+if sys.platform != 'win32' and sys.stdout.isatty():
+    BOLD = "\033[1m"
+    END = "\033[0m"
+
+def pretty_print(string):
+    """For *nix systems, augment TTY output. For others, strip such syntax."""
+    string = string.replace('$BOLD$', BOLD)
+    string = string.replace('$END$', END)
+    print string

--- a/core.py
+++ b/core.py
@@ -12,55 +12,90 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sqlite3
+"""Checks database for new phishing entries and executes alerts."""
+
+import os
 import sys
-from dnslib import dnslib
 import smtplib
 
-EMAIL_USERNAME = "EMAIL_ADDRESS_GOES_HERE"
-EMAIL_PASSWORD = "EMAIL_PASSWORD_GOES_HERE"
-EMAIL_STMPSERVER = "SMTP_SERVER_GOES_HERE"
+from dnslib import dnslib #dnslib.py
+import gfyp_db #gfyp_db.py
 
-#Code below taken from: http://stackoverflow.com/questions/10147455/trying-to-send-email-gmail-as-mail-provider-using-python
-def send_email(recipient, subject, body):
+#SET EMAIL SETTINGS HERE IF NOT USING ENVIRONMENT VARIABLES
+EMAIL_USERNAME = None
+EMAIL_PASSWORD = None
+EMAIL_STMPSERVER = None
 
-	FROM = EMAIL_USERNAME
-	TO = [recipient]
-	SUBJECT = subject
-	TEXT = body
+def send_email(smtp_auth, recipient, subject, body):
+    """Send email via SMTP.
+    Args:
+        smtp_auth (dict): Contains 'username' (str), 'password' (str), and
+            'server' (str).
+        recipient (str): The email address to send to
+        subject (str)
+        body (str)
 
-	#Sending message, first construct actual message
-	message = """\From: %s\nTo: %s\nSubject: %s\n\n%s
-	""" % (FROM, ", ".join(TO), SUBJECT, TEXT)
-	try:
-		server_ssl = smtplib.SMTP_SSL(EMAIL_STMPSERVER, 465)
-		server_ssl.ehlo()
-		server_ssl.login(EMAIL_USERNAME, EMAIL_PASSWORD)  
-		server_ssl.sendmail(FROM, TO, message)
-		server_ssl.close()
-	except:
-        	print "failed to send mail"
+    http://stackoverflow.com/questions/10147455/trying-to-send-email-gmail-as-mail-provider-using-python
+    """
+    email_to = [recipient]
+
+    #Sending message, first construct actual message
+    message = ("From: %s\nTo: %s\nSubject: %s\n\n%s" %
+               (smtp_auth['username'], ", ".join(email_to), subject, body))
+    try:
+        server_ssl = smtplib.SMTP_SSL(smtp_auth['server'], 465)
+        server_ssl.ehlo()
+        server_ssl.login(smtp_auth['username'], smtp_auth['password'])
+        server_ssl.sendmail(smtp_auth['username'], email_to, message)
+        server_ssl.close()
+    except Exception, err:
+        #TODO: log me
+        sys.exit("Failed to send mail: %s" % str(err))
+
+    print "Email sent to %s." % recipient
 
 def main():
-	dnsCheck = dnslib()
-	conn = sqlite3.connect('db.db')
-	c = conn.cursor()
-	domainentries =  c.execute('SELECT * FROM lookupTable').fetchall()
-	for row in domainentries:
-		print "Now checking %s - %s" % (row[0], row[1])
-		body = ""
-		entries = dnsCheck.checkDomain(row[1])
-		for entry in entries:
-			foundEntries = c.execute("SELECT * FROM foundDomains WHERE domainName = '%s'" % entry[0])
-			entriesIter = foundEntries.fetchall()
-			if len(entriesIter) == 0:
-				c.execute("INSERT INTO foundDomains VALUES ('%s','%s')" % (entry[0],entry[1]))
-				body = body+"\r\n\r\n%s - %s" % (entry[0],entry[1])
-				conn.commit()
-		if body != "":
-			send_email(row[0],'GFYP - New Entries for %s' % row[1],body) 
-	conn.commit()
-	conn.close()
+    """Description: Search for new domain variants and email alerts for new ones.
+    """
+    #Get configuration from env variables or fallback to hard-coded values
+    smtp_auth = dict()
+    smtp_auth['username'] = os.getenv('GFYP_EMAIL_USERNAME', EMAIL_USERNAME)
+    smtp_auth['password'] = os.getenv('GFYP_EMAIL_PASSWORD', EMAIL_PASSWORD)
+    smtp_auth['server'] = os.getenv('GFYP_EMAIL_STMPSERVER', EMAIL_STMPSERVER)
+    for key, value in smtp_auth.iteritems():
+        if value is None:
+            sys.exit("Fatal error: Email setting '%s' has not been set." % key)
+
+    if any([EMAIL_USERNAME, EMAIL_PASSWORD, EMAIL_STMPSERVER]):
+        print("WARNING: You have hard-coded credentials into a code file. Do "
+              "not commit it to a public Git repo!")
+
+    dns_check = dnslib()
+    with gfyp_db.DatabaseConnection() as db_con:
+        domain_entries = db_con.get_watch_entries()
+
+        if len(domain_entries) == 0:
+            print "No domains have been added for watching/alerts. Use util.py to add domains."
+
+        for row in domain_entries:
+            alert_email = row[0]
+            domain = row[1]
+            print "Now checking %s - %s" % (alert_email, domain)
+            body = ""
+            entries = dns_check.checkDomain(domain)
+            print "DNSTwist found %d variant domains from %s." % (len(entries), domain)
+            for domain_found, domain_info in entries:
+                found_entries = db_con.get_matching_found_domains(domain_found)
+                entries_iter = found_entries.fetchall()
+
+                if len(entries_iter) == 0:
+                    db_con.add_discovered_domain(domain_found, domain_info)
+                    body += "\r\n\r\n%s - %s" % (domain_found, domain_info)
+
+            if body != "":
+                recipient = alert_email
+                subject = 'GFYP - New Entries for %s' % domain
+                send_email(smtp_auth, recipient, subject, body)
 
 if __name__ == "__main__":
     main()

--- a/core.py
+++ b/core.py
@@ -25,7 +25,7 @@ from common import pretty_print #common.py
 #SET EMAIL SETTINGS HERE IF NOT USING ENVIRONMENT VARIABLES
 EMAIL_USERNAME = None
 EMAIL_PASSWORD = None
-EMAIL_STMPSERVER = None
+EMAIL_SMTPSERVER = None
 
 def send_email(smtp_auth, recipient, subject, body):
     """Send email via SMTP.
@@ -104,12 +104,12 @@ def main():
     smtp_auth = dict()
     smtp_auth['username'] = os.getenv('GFYP_EMAIL_USERNAME', EMAIL_USERNAME)
     smtp_auth['password'] = os.getenv('GFYP_EMAIL_PASSWORD', EMAIL_PASSWORD)
-    smtp_auth['server'] = os.getenv('GFYP_EMAIL_STMPSERVER', EMAIL_STMPSERVER)
+    smtp_auth['server'] = os.getenv('GFYP_EMAIL_SMTPSERVER', EMAIL_SMTPSERVER)
     for key, value in smtp_auth.iteritems():
         if value is None:
             sys.exit("Fatal error: Email setting '%s' has not been set." % key)
 
-    if any([EMAIL_USERNAME, EMAIL_PASSWORD, EMAIL_STMPSERVER]):
+    if any([EMAIL_USERNAME, EMAIL_PASSWORD, EMAIL_SMTPSERVER]):
         print("WARNING: You have hard-coded credentials into a code file. Do "
               "not commit it to a public Git repo!")
 

--- a/core.py
+++ b/core.py
@@ -55,7 +55,7 @@ def send_email(smtp_auth, recipient, subject, body):
 
     print "Email sent to %s." % recipient
 
-def check_and_send_alert(smtp_auth, alert_email, domain, escape_email=False,
+def check_and_send_alert(smtp_auth, alert_email, domain, escape_alert=False,
                          db_con=None):
     """Consult DB whether an alert needs to be sent for domain, and send one.
     Args:
@@ -63,7 +63,7 @@ def check_and_send_alert(smtp_auth, alert_email, domain, escape_email=False,
             'password', and 'server'.
         alert_email (str)
         domain (str)
-        escape_email (bool): Whether or not to escape periods in the email body
+        escape_alert (bool): Whether or not to escape periods in the email body
             in order to avoid spam filtering. (Default: False)
         db_con (None or `gfyp_db.DatabaseConnection`): This can optionally
             provide a database connection to reuse. Otherwise, a new one will
@@ -89,6 +89,8 @@ def check_and_send_alert(smtp_auth, alert_email, domain, escape_email=False,
     if body != "":
         recipient = alert_email
         subject = 'GFYP - New Entries for %s' % domain
+        if escape_alert:
+            body = body.replace('.', '[.]')
         send_email(smtp_auth, recipient, subject, body)
 
     if close_db:
@@ -123,7 +125,7 @@ def main():
             domain = row[1]
             check_and_send_alert(
                 smtp_auth, alert_email, domain,
-                escape_email=args['escape_email'], db_con=db_con)
+                escape_alert=args['escape_alert'], db_con=db_con)
 
 def usage():
     """Print usage info."""

--- a/dnslib.py
+++ b/dnslib.py
@@ -8,7 +8,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
@@ -22,100 +22,101 @@
 
 from dnstwist import DomainFuzz
 try:
-	import dns.resolver
-	module_dnspython = True
+    import dns.resolver
+    module_dnspython = True
 except:
-	module_dnspython = False
-	pass
+    module_dnspython = False
+    pass
 try:
-	import whois
-	module_whois = True
+    import whois
+    module_whois = True
 except:
-	module_whois = False
-	pass
+    module_whois = False
+    pass
 
-class dnslib:		
-	
-	def __init__(self):
-		#Putting this here for now as a placeholder for the dynamic fuzzing code I'm working on.
-		self.domains = []
+class dnslib:
 
-	def checkDomain(self,dnsEntryName):
-		fuzzer = DomainFuzz(dnsEntryName.lower())
-		fuzzer.generate()
-		domains = fuzzer.domains
-	
-		total_hits = 0
-	
-		for i in range(0, len(domains)):
-			if module_dnspython:
-				resolv = dns.resolver.Resolver()
-				resolv.lifetime = 1
-				resolv.timeout = 1
-	
-				try:
-					ns = resolv.query(domains[i]['domain-name'], 'NS')
-					domains[i]['ns'] = str(ns[0])[:-1].lower()
-				except:
-					pass
-	
-				if 'ns' in domains[i]:
-					try:
-						ns = resolv.query(domains[i]['domain-name'], 'A')
-						domains[i]['a'] = str(ns[0])
-					except:
-						pass
-		
-					try:
-						ns = resolv.query(domains[i]['domain-name'], 'AAAA')
-						domains[i]['aaaa'] = str(ns[0])
-					except:
-						pass
-	
-					try:
-						mx = resolv.query(domains[i]['domain-name'], 'MX')
-						domains[i]['mx'] = str(mx[0].exchange)[:-1].lower()
-					except:
-						pass
-	
-			if 'ns' in domains[i] or 'a' in domains[i]:
-				try:
-					whoisdb = whois.query(domains[i]['domain-name'])
-					domains[i]['created'] = str(whoisdb.creation_date).replace(' ', 'T')
-					domains[i]['updated'] = str(whoisdb.last_updated).replace(' ', 'T')
-				except:
-					pass
-		
-		returnDomains = []
-		for i in domains:
-			info = ''
-	
-			if 'a' in i:
-				info += i['a']
-				if 'country' in i:
-					info += '/' + i['country']
-				if 'banner-http' in i:
-					info += ' HTTP:"%s"' % i['banner-http']
-			elif 'ns' in i:
-				info += 'NS:' + i['ns']
-	
-			if 'aaaa' in i:
-				info += ' ' + i['aaaa']
-	
-			if 'mx' in i:
-				info += ' MX:' + i['mx']
-				if 'banner-smtp' in i:
-					info += ' SMTP:"%s"' % i['banner-smtp']
-	
-			if 'created' in i and 'updated' in i and i['created'] == i['updated']:
-				info += ' Created/Updated:' + i['created']
-			else:
-				if 'created' in i:
-					info += ' Created:' + i['created']
-				if 'updated' in i:
-					info += ' Updated:' + i['updated']
-	
-			if info:
-				returnDomains.append([i['domain-name'],info])	
-	
-		return returnDomains
+    def __init__(self):
+        #Putting this here for now as a placeholder for the dynamic fuzzing code I'm working on.
+        self.domains = []
+
+    def checkDomain(self,dnsEntryName):
+        """TODO: describe arguments and return value!"""
+        fuzzer = DomainFuzz(dnsEntryName.lower())
+        fuzzer.generate()
+        domains = fuzzer.domains
+
+        total_hits = 0
+
+        for i in range(0, len(domains)):
+            if module_dnspython:
+                resolv = dns.resolver.Resolver()
+                resolv.lifetime = 1
+                resolv.timeout = 1
+
+                try:
+                    ns = resolv.query(domains[i]['domain-name'], 'NS')
+                    domains[i]['ns'] = str(ns[0])[:-1].lower()
+                except:
+                    pass
+
+                if 'ns' in domains[i]:
+                    try:
+                        ns = resolv.query(domains[i]['domain-name'], 'A')
+                        domains[i]['a'] = str(ns[0])
+                    except:
+                        pass
+
+                    try:
+                        ns = resolv.query(domains[i]['domain-name'], 'AAAA')
+                        domains[i]['aaaa'] = str(ns[0])
+                    except:
+                        pass
+
+                    try:
+                        mx = resolv.query(domains[i]['domain-name'], 'MX')
+                        domains[i]['mx'] = str(mx[0].exchange)[:-1].lower()
+                    except:
+                        pass
+
+            if 'ns' in domains[i] or 'a' in domains[i]:
+                try:
+                    whoisdb = whois.query(domains[i]['domain-name'])
+                    domains[i]['created'] = str(whoisdb.creation_date).replace(' ', 'T')
+                    domains[i]['updated'] = str(whoisdb.last_updated).replace(' ', 'T')
+                except:
+                    pass
+
+        returnDomains = []
+        for i in domains:
+            info = ''
+
+            if 'a' in i:
+                info += i['a']
+                if 'country' in i:
+                    info += '/' + i['country']
+                if 'banner-http' in i:
+                    info += ' HTTP:"%s"' % i['banner-http']
+            elif 'ns' in i:
+                info += 'NS:' + i['ns']
+
+            if 'aaaa' in i:
+                info += ' ' + i['aaaa']
+
+            if 'mx' in i:
+                info += ' MX:' + i['mx']
+                if 'banner-smtp' in i:
+                    info += ' SMTP:"%s"' % i['banner-smtp']
+
+            if 'created' in i and 'updated' in i and i['created'] == i['updated']:
+                info += ' Created/Updated:' + i['created']
+            else:
+                if 'created' in i:
+                    info += ' Created:' + i['created']
+                if 'updated' in i:
+                    info += ' Updated:' + i['updated']
+
+            if info:
+                returnDomains.append([i['domain-name'],info])
+
+        return returnDomains

--- a/gfyp_db.py
+++ b/gfyp_db.py
@@ -1,0 +1,132 @@
+"""Functions for interacting with the database."""
+import sqlite3
+
+DB_FILENAME_DEFAULT = 'db.db'
+
+class DatabaseConnection(object):
+    """A connection to the database.
+
+    Usage:
+        with gfyp_db.DatabaseConnection() as db_con:
+            db_con.foo()
+            ...
+    """
+
+    def __init__(self, filename=DB_FILENAME_DEFAULT):
+        self.filename = filename
+        self.conn = sqlite3.connect(self.filename)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exec_type, exec_value, exec_traceback):
+        self.conn.close()
+
+    def table_init(self):
+        """Initialize database with required tables.
+
+        Return: bool: Whether any errors were encounterd.
+        """
+        is_err = False
+        try:
+            self.sql_execute(
+                "CREATE TABLE lookupTable(emailAddy text, domainName text)")
+        except sqlite3.OperationalError, err:
+            print "Error creating table: %s" % str(err)
+            is_err = True
+
+        try:
+            self.sql_execute(
+                "CREATE TABLE foundDomains(domainName text, info text)")
+        except sqlite3.OperationalError, err:
+            print "Error creating table: %s" % str(err)
+            is_err = True
+        return is_err
+
+    def add_watch_entry(self, domain_name, alert_email):
+        """Add a domain to monitor for phishing variants."""
+        stmt = "INSERT INTO lookupTable VALUES (?, ?)"
+        arglist = (alert_email, domain_name)
+        num_changes = self.sql_execute(stmt, arglist)
+        if num_changes == 1:
+            print "Added domain %s for monitoring." % domain_name
+        elif num_changes == 0:
+            print "No domains added for monitoring! Already present?"
+        else:
+            print "Made more database changes (%d) than expected!" % num_changes
+
+    def delete_watch_entry(self, domain_name):
+        """Delete all entries for monitoring for specified domain."""
+        stmt = "DELETE FROM lookupTable WHERE lookupTable.domainName = ?"
+        arglist = (domain_name,)
+        num_changes = self.sql_execute(stmt, arglist)
+        if num_changes == 0:
+            print "No domains removed from monitoring! Not already present?"
+        else:
+            print("Removed %s from monitoring and removed %d alert%s." %
+                  (domain_name, num_changes, 's' if num_changes != 1 else ''))
+
+    def get_watch_entries(self):
+        """Get a list of (email, domain) entries monitored for phishing variants.
+
+        Returns: List of tuples (alert_email, domain) of length >= 0
+        """
+        cur = self.conn.cursor()
+        domain_entries = cur.execute('SELECT * FROM lookupTable').fetchall()
+        return domain_entries
+
+    def get_all_found_domains(self):
+        """Get list of (domain, info) previously found.
+
+        Returns: List of tuples (domain, info) of length >= 0
+        """
+        cur = self.conn.cursor()
+        info_entries = cur.execute("SELECT * FROM foundDomains")
+        return info_entries
+
+    def delete_found_domain(self, domain_name):
+        """Delete all entries from list of domains found that match domain."""
+        stmt = "DELETE FROM foundDomains WHERE foundDomains.domainName = ?"
+        arglist = (domain_name,)
+        num_changes = self.sql_execute(stmt, arglist)
+        if num_changes == 0:
+            print "No domains removed from list! Not previously found?"
+        elif num_changes == 1:
+            print("Removed domain %s from list of previously discovered domains." %
+                  domain_name)
+        else:
+            print "Made more database changes (%d) than expected!" % num_changes
+
+    def get_matching_found_domains(self, domain_name):
+        """Get list of (domain, info) previously found matching specified domain.
+
+        Returns: List of tuples (domain, info) of length >= 0
+        """
+        cur = self.conn.cursor()
+        stmt = "SELECT * FROM foundDomains WHERE domainName = ?"
+        arglist = (domain_name,)
+        info_entries = cur.execute(stmt, arglist)
+        return info_entries
+
+    def add_discovered_domain(self, domain_name, domain_info):
+        """Add a new domain to list of domains discovered by dnstwist.
+        Args:
+            domain_name (str): The name of the domain, e.g. 'example.com'.
+            domain_info (str): Additiona DNS information from DNS lookup.
+        """
+        cur = self.conn.cursor()
+        stmt = "INSERT INTO foundDomains VALUES (?, ?)"
+        arglist = (domain_name, domain_info)
+        cur.execute(stmt, arglist)
+        self.conn.commit()
+
+    def sql_execute(self, stmt, arglist=None):
+        """Execute the SQL statement and return number of db changes."""
+        cur = self.conn.cursor()
+        if arglist is not None:
+            cur.execute(stmt, arglist)
+        else:
+            cur.execute(stmt)
+        self.conn.commit()
+        num_changes = self.conn.total_changes
+        return num_changes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 db-sqlite3
+dnspython

--- a/util.py
+++ b/util.py
@@ -4,12 +4,7 @@
 import sys
 import csv
 import gfyp_db #gfyp_db.py
-
-BOLD = ""
-END = ""
-if sys.platform != 'win32' and sys.stdout.isatty():
-    BOLD = "\033[1m"
-    END = "\033[0m"
+from common import pretty_print #common.py
 
 def usage():
     """Print usage info."""
@@ -28,13 +23,8 @@ def usage():
         "domain from the found entries\n"
         "    $BOLD$dump$END$ (file name) - Writes the contents of the found "
         "domain name table into the file in CSV format")
-    _pretty_print(usage_str)
+    pretty_print(usage_str)
     sys.exit()
-
-def _pretty_print(string):
-    string = string.replace('$BOLD$', BOLD)
-    string = string.replace('$END$', END)
-    print string
 
 def dump():
     """Write database to CSV file."""

--- a/util.py
+++ b/util.py
@@ -5,21 +5,33 @@ import sqlite3
 import sys
 import csv
 
+BOLD = "\033[1m"
+END = "\033[0m"
+
 def usage():
     """Print usage info."""
-    print("GFYP Utilities\n"
-          "python utils.py (utility function argument) (function parameters "
-          "space separated)\n"
-          "Current supported utility functions:\n"
-          "usage - prints this message\n"
-          "build - creates a blank database named db.db\n"
-          "add (domain name) (email address) - inserts a new domain to monitor "
-          "into db.db\n"
-          "removemonitor (domain name) - removes a domain from being monitored\n"
-          "removeentry (domain name) - removes an identified domain from the "
-          "found entries\n"
-          "dump (file name) - Writes the contents of the found domain name "
-          "table into the file in CSV format")
+    usage_str = (
+        "GFYP Utilities\n"
+        "usage: python utils.py <$BOLD$command$END$> [command parameters space "
+        "separated]\n"
+        "Commands:\n"
+        "    $BOLD$usage$END$ - prints this message\n"
+        "    $BOLD$build$END$ - creates a blank database named db.db\n"
+        "    $BOLD$add$END$ (domain name) (email address) - inserts a new "
+        "domain to monitor into db.db\n"
+        "    $BOLD$removemonitor$END$ (domain name) - removes a domain from "
+        "being monitored\n"
+        "    $BOLD$removeentry$END$ (domain name) - removes an identified "
+        "domain from the found entries\n"
+        "    $BOLD$dump$END$ (file name) - Writes the contents of the found "
+        "domain name table into the file in CSV format")
+    _pretty_print(usage_str)
+
+def _pretty_print(string):
+    string = string.replace('$BOLD$', BOLD)
+    string = string.replace('$END$', END)
+    print string
+
 
 def dump():
     """Write database to CSV file."""

--- a/util.py
+++ b/util.py
@@ -5,8 +5,11 @@ import sys
 import csv
 import gfyp_db #gfyp_db.py
 
-BOLD = "\033[1m"
-END = "\033[0m"
+BOLD = ""
+END = ""
+if sys.platform != 'win32' and sys.stdout.isatty():
+    BOLD = "\033[1m"
+    END = "\033[0m"
 
 def usage():
     """Print usage info."""


### PR DESCRIPTION
This PR builds on the env-vars-config PR (https://github.com/0xd34db33f/gfyp/pull/4).

Aside from a little refactoring, the feature included is an optional command-line arg to core.py. I was using a throwaway gmail account for SMTP and finding that my alert emails were rejected by the gmail server because they included references to known-bad domains. The workaround is simply to replace the period in domains and ip addresses with “[.]” in the alert email.

Testing: Wiped out the list of found domains and ran core.py. Received email as expected. Confirmed that the email looks fine. Test environment: MacOS VM.